### PR TITLE
Create context

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,0 +1,4 @@
+# Discord
+
+[DiscordにGitHubの通知(Webhook)](https://zenn.dev/hyouhyan/articles/2bacb379d1a826
+)

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -2,3 +2,56 @@
 
 [DiscordにGitHubの通知(Webhook)](https://zenn.dev/hyouhyan/articles/2bacb379d1a826
 )
+
+今回は時間やセキュリティの都合やカスタムする内容が多くなるために省いたが、
+
+レビュアーを指定した上でのプルリク通知も可能
+
+`.github/workflows/notify.yml`
+```
+name: Discord PR Reviewer Notification
+
+on:
+  pull_request:
+    types: [review_requested] # レビュアーがリクエストされた時に実行
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      # レビュアーのGitHubユーザー名から、対応するDiscord IDを探し、メンション用の文字列を作成するステップ
+      - name: Build Mention String
+        id: build_mention
+        env:
+          # SecretsからJSON形式の対応表と、イベントからレビュアーのログイン名を取得
+          USER_MAP_JSON: ${{ secrets.DISCORD_USER_MAP }}
+          REVIEWER_LOGIN: ${{ github.event.requested_reviewer.login }}
+        run: |
+          # 'jq'というツールを使ってJSONを解析します。
+          # まず、jqがインストールされているか確認し、なければインストールします。
+          if ! command -v jq &> /dev/null
+          then
+              sudo apt-get update && sudo apt-get install -y jq
+          fi
+          
+          # JSONの中から、レビュアーのログイン名に一致するDiscord IDを検索
+          DISCORD_ID=$(echo "$USER_MAP_JSON" | jq -r --arg LOGIN "$REVIEWER_LOGIN" '.[$LOGIN]')
+
+          # Discord IDが見つかった場合のみ、メンション用の文字列を作成
+          if [ "$DISCORD_ID" != "null" ] && [ -n "$DISCORD_ID" ]; then
+            echo "mention_string=<@$DISCORD_ID>" >> $GITHUB_OUTPUT
+          else
+            echo "mention_string=" >> $GITHUB_OUTPUT
+          fi
+
+      # Discordに通知を送るステップ
+      - name: Send Discord Notification
+        uses: ahmadnassri/action-discord@v2
+        with:
+          # Webhook URLも必ずSecretから読み込む
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          message: |
+            ${{ steps.build_mention.outputs.mention_string }}
+            **${{ github.actor }}** さんがプルリクエストで、あなたをレビュアーに指定しました。
+            > [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { useDataContext } from './contexts/DataContext';
 
 // メインのAppコンポーネント
 export default function App() {
-  const { labs, reviews, setReviews, page, setPage } = useDataContext();
+  const { labs, reviews, page } = useDataContext();
   const [loading, setLoading] = useState<boolean>(true);
   const [selectedLab, setSelectedLab] = useState<LabWithReview | null>(null);
 
@@ -41,7 +41,7 @@ export default function App() {
       case 'chart':
         return <ReviewChartPage/>;
       case 'form':
-        return <ReviewFormPage labs={labs} setPage={setPage} setReviews={setReviews} />;
+        return <ReviewFormPage/>;
       case 'home':
       default:
         return <HomePage labs={labs} reviews={reviews} onReviewClick={handleReviewClick} />;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { useDataContext } from './contexts/DataContext';
 
 // メインのAppコンポーネント
 export default function App() {
-  const { labs, reviews, page } = useDataContext();
+  const { page } = useDataContext();
   const [loading, setLoading] = useState<boolean>(true);
   const [selectedLab, setSelectedLab] = useState<LabWithReview | null>(null);
 
@@ -44,7 +44,7 @@ export default function App() {
         return <ReviewFormPage/>;
       case 'home':
       default:
-        return <HomePage labs={labs} reviews={reviews} onReviewClick={handleReviewClick} />;
+        return <HomePage onReviewClick={handleReviewClick} />;
     }
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,7 @@ export default function App() {
       <main className="container mx-auto p-4 md:p-6">
         {renderPage()}
       </main>
-      <ReviewModal lab={selectedLab} reviews={reviews} onClose={handleCloseModal} />
+      <ReviewModal lab={selectedLab} onClose={handleCloseModal} />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ export default function App() {
     }
     switch (page) {
       case 'chart':
-        return <ReviewChartPage />;
+        return <ReviewChartPage/>;
       case 'form':
         return <ReviewFormPage labs={labs} setPage={setPage} setReviews={setReviews} />;
       case 'home':
@@ -54,7 +54,7 @@ export default function App() {
 
   return (
     <div className="bg-gray-50 min-h-screen font-sans">
-      <Header setPage={setPage} />
+      <Header/>
       <main className="container mx-auto p-4 md:p-6">
         {renderPage()}
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ export default function App() {
     }
     switch (page) {
       case 'chart':
-        return <ReviewChartPage reviews={reviews} />;
+        return <ReviewChartPage />;
       case 'form':
         return <ReviewFormPage labs={labs} setPage={setPage} setReviews={setReviews} />;
       case 'home':

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,6 @@
 import { useState, useEffect } from 'react';
 // --- 型定義のためのインポート ---
-import type { Lab, Review, LabWithReview, Page } from './types/'
-
-// 初期データ
-import {initialLabs, initialReviews } from './data/'
+import type { LabWithReview } from './types/'
 
 // コンポーネント
 import Header from './components/Header';
@@ -14,18 +11,17 @@ import HomePage from './pages/HomePage';
 import ReviewChartPage from './pages/ReviewChartPage';
 import ReviewFormPage from './pages/ReviewFormPage';
 
+// コンテキスト
+import { useDataContext } from './contexts/DataContext';
+
 // メインのAppコンポーネント
 export default function App() {
-  const [page, setPage] = useState<Page>('home');
-  const [labs, setLabs] = useState<Lab[]>([]);
-  const [reviews, setReviews] = useState<Review[]>([]);
+  const { labs, reviews, setReviews, page, setPage } = useDataContext();
   const [loading, setLoading] = useState<boolean>(true);
   const [selectedLab, setSelectedLab] = useState<LabWithReview | null>(null);
 
   useEffect(() => {
     // データベースの代わりに初期データをセットする
-    setLabs(initialLabs);
-    setReviews(initialReviews);
     setLoading(false);
   }, []);
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,12 @@
 import type { FC } from 'react';
-import type { Dispatch, SetStateAction } from 'react';
-import type { Page } from '.././types/'
-
 import { Plus, BarChart2, Home } from 'lucide-react';
 
-interface HeaderProps {
-  setPage: Dispatch<SetStateAction<Page>>;
-}
+import { useDataContext } from '.././contexts/DataContext';
 
 // ヘッダーコンポーネント
-const Header: FC<HeaderProps> = ({ setPage }) => (
+const Header: FC = () => {
+  const { setPage } = useDataContext(); // Contextから直接setPageを取得
+  return (
   <header className="bg-white shadow-md sticky top-0 z-20">
     <div className="container mx-auto px-4 py-3 flex justify-between items-center">
       <h1 className="text-xl md:text-2xl font-bold text-gray-800">LabNavi</h1>
@@ -26,6 +23,7 @@ const Header: FC<HeaderProps> = ({ setPage }) => (
       </nav>
     </div>
   </header>
-);
+  )
+};
 
 export default Header;

--- a/src/components/ReviewModal.tsx
+++ b/src/components/ReviewModal.tsx
@@ -3,17 +3,19 @@
 // 画面の最前面に優先して出てくる詳細なレビュー一覧のこと
 
 import type { FC } from 'react';
-import type { Review, LabWithReview } from '.././types/'
+import type { LabWithReview } from '.././types/'
 
 import { X } from 'lucide-react';
 
+import { useDataContext } from '.././contexts/DataContext';
+
 export interface ReviewModalProps {
   lab: LabWithReview | null;
-  reviews: Review[];
   onClose: () => void;
 }
 
-const ReviewModal: FC<ReviewModalProps> = ({ lab, reviews, onClose }) => {
+const ReviewModal: FC<ReviewModalProps> = ({ lab, onClose }) => {
+    const { reviews } = useDataContext();
     if (!lab) return null;
 
     const labReviews = reviews.filter(r => r.labId === lab.id);

--- a/src/context/DataContext.tsx
+++ b/src/context/DataContext.tsx
@@ -1,0 +1,55 @@
+import { createContext, useState, useEffect, useMemo, useContext } from 'react';
+import type { FC, ReactNode, Dispatch, SetStateAction } from 'react';
+import type { Lab, Review, Page } from '../types';
+import { initialLabs, initialReviews } from '../data/';
+
+// Contextが提供する値の型を定義
+interface DataContextType {
+  labs: Lab[];        // 研究室情報は複数のページで扱う、かつ今後動的に内容が変わる可能性があるため、バケツリレーになりやすい
+  setLabs: Dispatch<SetStateAction<Lab[]>>;
+  reviews: Review[];  // レビュー投稿もあり、データが動的に変わりやすい、いちいち引数で渡し合うのも不便である
+  setReviews: Dispatch<SetStateAction<Review[]>>;
+  page: Page;         // 色んなページ移動が起こるため、引数で渡し合うのは冗長
+  setPage: Dispatch<SetStateAction<Page>>;
+}
+
+// 2. Contextオブジェクトを作成 (初期値はnull)
+const DataContext = createContext<DataContextType | null>(null);
+
+// 子コンポーネントにContextを提供するためのProviderコンポーネントを作成
+export const DataProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  // Data.tsxにあった状態管理ロジックをここに移動
+  const [labs, setLabs] = useState<Lab[]>([]);
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [page, setPage] = useState<Page>('home');
+
+  useEffect(() => {
+    setLabs(initialLabs);
+    setReviews(initialReviews);
+  }, []);
+
+  // useMemoを使って、Contextの値が不必要に再生成されるのを防ぐ
+  const value = useMemo(() => ({
+    labs,
+    setLabs,
+    reviews,
+    setReviews,
+    page,
+    setPage,
+  }), [page, labs, reviews]);
+
+  return (
+    <DataContext.Provider value={value}>
+      {children}
+    </DataContext.Provider>
+  );
+};
+
+// 4. Contextを簡単に利用するためのカスタムフックを作成
+export const useDataContext = () => {
+  const context = useContext(DataContext);
+  if (!context) {
+    throw new Error('useDataContext must be used within an DataProvider');
+  }
+  return context;
+};

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useState, useEffect, useMemo, useContext } from 'react';
 import type { FC, ReactNode, Dispatch, SetStateAction } from 'react';
 import type { Lab, Review, Page } from '../types';
-import { initialLabs, initialReviews } from '../data/';
+import { initialLabs, initialReviews } from '../data';
 
 // Contextが提供する値の型を定義
 interface DataContextType {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { DataProvider } from './contexts/DataContext.tsx'; // 作成したProviderをインポート
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <DataProvider>
+      <App />
+    </DataProvider>
   </StrictMode>,
 )

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,18 +1,19 @@
 import { useState, useMemo } from 'react';
 
 import type { FC } from 'react';
-import type { Lab, Review, LabWithReview } from '.././types/'
+import type { LabWithReview } from '.././types/'
 
 import { Search, Star } from 'lucide-react';
 
+import { useDataContext } from '.././contexts/DataContext';
+
 interface HomePageProps {
-  labs: Lab[];
-  reviews: Review[];
   onReviewClick: (lab: LabWithReview) => void;
 }
 
 // ホームページコンポーネント
-const HomePage: FC<HomePageProps> = ({ labs, reviews, onReviewClick }) => {
+const HomePage: FC<HomePageProps> = ({ onReviewClick }) => {
+  const { labs, reviews } = useDataContext();
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   const filteredLabs: LabWithReview[] = useMemo(() => {

--- a/src/pages/ReviewChartPage.tsx
+++ b/src/pages/ReviewChartPage.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import type { FC } from 'react';
 // --- TooltipPropsの型インポートを修正 ---
 import type { TooltipProps } from 'recharts';
-import type { Review } from '.././types/'
 
 import {
   ResponsiveContainer,
@@ -16,12 +15,12 @@ import {
   Tooltip,
 } from 'recharts';
 
-interface ReviewChartPageProps {
-  reviews: Review[];
-}
+import { useDataContext } from '.././contexts/DataContext';
 
 // レビューグラフページ
-const ReviewChartPage: FC<ReviewChartPageProps> = ({ reviews }) => {
+const ReviewChartPage: FC = () => {
+  const { reviews } = useDataContext(); // Contextから直接setPageを取得
+
   const chartData = useMemo(() => {
     const labReviews: { [key: string]: { name: string; strict: number[]; supportive: number[] } } = {};
     reviews.forEach(review => {

--- a/src/pages/ReviewFormPage.tsx
+++ b/src/pages/ReviewFormPage.tsx
@@ -3,16 +3,12 @@
 import React, { useState } from 'react';
 
 import type { FC } from 'react';
-import type { Dispatch, SetStateAction } from 'react';
-import type { Review, Lab, Page } from '.././types/'
+import type { Review } from '.././types/'
 
-export interface ReviewFormPageProps {
-  labs: Lab[];
-  setPage: Dispatch<SetStateAction<Page>>;
-  setReviews: Dispatch<SetStateAction<Review[]>>;
-}
+import { useDataContext } from '.././contexts/DataContext';
 
-const ReviewFormPage: FC<ReviewFormPageProps> = ({ labs, setPage, setReviews }) => {
+const ReviewFormPage: FC = () => {
+  const { labs, setPage, setReviews } = useDataContext();
   const [labId, setLabId] = useState<string>('');
   const [strict, setStrict] = useState<number>(5);
   const [supportive, setSupportive] = useState<number>(5);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,5 +26,5 @@ export interface LabWithReview extends Lab {
   reviewCount: number;
 }
 
-// --- コンポーネントのProps型定義 ---
+// pageの型定義, これを状態として管理することで、状態がセットされるたびに際レンダリングが自動で開始
 export type Page = 'home' | 'chart' | 'form';


### PR DESCRIPTION
useContextによるリファクタリングの実装
これにより
・余計な型定義の削除
・データのバケツリレーを防げる
・追加機能を作るときに、わざわざ引数を使ってデータを得るなどの手間を省ける
   (関数呼び出し元の余計な変更も減らせる)

今回はとりあえず動的に変更されるデータ
labs, reviews, pageに絞って実装