### PR TITLE
Feat/award modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 // --- 型定義のためのインポート ---
-import type { LabWithReview } from './types/'
+import type { LabWithReview, } from './types/'
 
 // コンポーネント
 import Header from './components/Header';
 import ReviewModal from './components/ReviewModal';
+import AwardModal from './components/AwardModal'; 
 
 // ページ
 import HomePage from './pages/HomePage';
@@ -19,6 +20,7 @@ export default function App() {
   const { page } = useDataContext();
   const [loading, setLoading] = useState<boolean>(true);
   const [selectedLab, setSelectedLab] = useState<LabWithReview | null>(null);
+  const [selectedLabForAwards, setSelectedLabForAwards] = useState<LabWithReview | null>(null);
 
   useEffect(() => {
     // データベースの代わりに初期データをセットする
@@ -33,6 +35,14 @@ export default function App() {
       setSelectedLab(null);
   };
 
+  const handleAwardsClick = (lab: LabWithReview) => {
+      setSelectedLabForAwards(lab);
+  };
+
+  const handleCloseAwardModal = () => {
+      setSelectedLabForAwards(null);
+  };
+
   const renderPage = () => {
     if (loading) {
       return <div className="text-center py-10">読み込み中...</div>;
@@ -44,7 +54,7 @@ export default function App() {
         return <ReviewFormPage/>;
       case 'home':
       default:
-        return <HomePage onReviewClick={handleReviewClick} />;
+        return <HomePage onReviewClick={handleReviewClick} onAwardsClick={handleAwardsClick} />;
     }
   };
 
@@ -55,6 +65,7 @@ export default function App() {
         {renderPage()}
       </main>
       <ReviewModal lab={selectedLab} onClose={handleCloseModal} />
+      <AwardModal lab={selectedLabForAwards} onClose={handleCloseAwardModal} />
     </div>
   );
 }

--- a/src/components/AwardModal.tsx
+++ b/src/components/AwardModal.tsx
@@ -1,0 +1,50 @@
+// src/components/AwardModal.tsx (新規作成)
+
+import type { FC } from 'react';
+import type { LabWithReview } from '../types/';
+import { X } from 'lucide-react';
+import { useDataContext } from '../contexts/DataContext';
+
+export interface AwardModalProps {
+  lab: LabWithReview | null;
+  onClose: () => void;
+}
+
+const AwardModal: FC<AwardModalProps> = ({ lab, onClose }) => {
+  const { awards } = useDataContext();
+  if (!lab) return null;
+
+  const labAwards = awards.filter(a => a.labId === lab.id);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col">
+        <div className="p-4 border-b flex justify-between items-center">
+          <h2 className="text-xl font-bold text-gray-800">{lab.name} の受賞歴</h2>
+          <button onClick={onClose} className="p-1 rounded-full hover:bg-gray-200">
+            <X className="h-6 w-6 text-gray-600" />
+          </button>
+        </div>
+        <div className="p-4 overflow-y-auto">
+          {labAwards.length > 0 ? (
+            <ul className="space-y-3 list-disc list-inside">
+              {labAwards.map((award) => (
+                <li key={award.id} className="text-gray-700">
+                  <span className="font-semibold">{award.awardName}</span>
+                  <span className="text-sm text-gray-500 ml-2">({award.awardedAt})</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-gray-500 text-center py-8">この研究室の受賞歴情報はありません。</p>
+          )}
+        </div>
+        <div className="p-4 border-t text-right">
+          <button onClick={onClose} className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 transition">閉じる</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AwardModal;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,17 @@ const Header: FC = () => {
   return (
   <header className="bg-white shadow-md sticky top-0 z-20">
     <div className="px-6 py-3 flex justify-between items-center">
-      <h1 className="text-xl md:text-2xl font-bold text-gray-800">LabNavi</h1>
+      <div className="flex items-center">
+        <img
+        src="/favicon.png"
+        alt="LabNavi logo"
+        className="h-8 w-8 mr-2" // 画像のサイズと右の余白
+      />
+      
+      <h1 className="text-xl md:text-2xl font-bold text-gray-800">
+      LabNavi
+      </h1>
+    </div>
       <nav className="flex items-center space-x-2">
         <button onClick={() => setPage('home')} className="p-2 rounded-full hover:bg-gray-100 transition-colors" title="ホーム">
           <Home className="h-5 w-5 text-gray-600" />

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,7 +1,9 @@
 import { createContext, useState, useEffect, useMemo, useContext } from 'react';
 import type { FC, ReactNode, Dispatch, SetStateAction } from 'react';
-import type { Lab, Review, Page } from '../types';
-import { initialLabs, initialReviews } from '../data';
+import type { Lab, Review, Page, Award } from '../types';
+import { initialLabs, initialReviews, initialAwards } from '../data';
+
+
 
 // Contextが提供する値の型を定義
 interface DataContextType {
@@ -11,6 +13,8 @@ interface DataContextType {
   setReviews: Dispatch<SetStateAction<Review[]>>;
   page: Page;         // 色んなページ移動が起こるため、引数で渡し合うのは冗長
   setPage: Dispatch<SetStateAction<Page>>;
+  awards: Award[]; // ▼ awardsの型定義を追加
+  setAwards: Dispatch<SetStateAction<Award[]>>; // ▼ setAwardsの型定義を追加
 }
 
 // 2. Contextオブジェクトを作成 (初期値はnull)
@@ -22,10 +26,12 @@ export const DataProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [labs, setLabs] = useState<Lab[]>([]);
   const [reviews, setReviews] = useState<Review[]>([]);
   const [page, setPage] = useState<Page>('home');
+  const [awards, setAwards] = useState<Award[]>([]); // ▼ awards用の状態を追加
 
   useEffect(() => {
     setLabs(initialLabs);
     setReviews(initialReviews);
+    setAwards(initialAwards); // ▼ awardsの初期データをセット
   }, []);
 
   // useMemoを使って、Contextの値が不必要に再生成されるのを防ぐ
@@ -36,7 +42,10 @@ export const DataProvider: FC<{ children: ReactNode }> = ({ children }) => {
     setReviews,
     page,
     setPage,
-  }), [page, labs, reviews]);
+    awards, // ▼ valueにawardsを追加
+    setAwards, // ▼ valueにsetAwardsを追加
+  }), [page, labs, reviews, awards]); // ▼ 依存配列にawardsを追加
+
 
   return (
     <DataContext.Provider value={value}>

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -71,9 +71,47 @@ export const initialReviews: Review[] = [
 
 // ▼ この部分を追記
 export const initialAwards: Award[] = [
+  // --- システム制御論研究室 (3件) ---
   { id: 1, labId: 'system_control', awardName: 'ロボティクス学会 年次大会優秀講演賞', awardedAt: '2024年9月' },
   { id: 2, labId: 'system_control', awardName: '国際自動制御連盟 世界大会ポスター賞', awardedAt: '2023年7月' },
-  { id: 3, labId: 'materials_science', awardName: '応用物理学会 論文賞', awardedAt: '2024年3月' },
-  { id: 4, labId: 'ai_robotics', awardName: 'CVPR Best Paper Award', awardedAt: '2023年6月' },
-  { id: 5, labId: 'ai_robotics', awardName: 'ICML Outstanding Paper Award', awardedAt: '2024年7月' },
+  { id: 3, labId: 'system_control', awardName: '計測自動制御学会 論文賞', awardedAt: '2022年11月' },
+
+  // --- 通信方式研究室 (5件) ---
+  { id: 4, labId: 'communication_theory', awardName: 'IEEE VTC Best Paper Award', awardedAt: '2024年5月' },
+  { id: 5, labId: 'communication_theory', awardName: '電子情報通信学会 業績賞', awardedAt: '2023年10月' },
+  { id: 6, labId: 'communication_theory', awardName: 'Globecom Student Travel Grant', awardedAt: '2023年12月' },
+  { id: 7, labId: 'communication_theory', awardName: '総務省SCOPE採択', awardedAt: '2022年4月' },
+  { id: 8, labId: 'communication_theory', awardName: 'IEEE ICC Poster Award', awardedAt: '2022年5月' },
+
+  // --- 材料科学研究室 (8件) ---
+  { id: 9, labId: 'materials_science', awardName: '応用物理学会 論文賞', awardedAt: '2024年3月' },
+  { id: 10, labId: 'materials_science', awardName: '日本MRS年次大会 奨励賞', awardedAt: '2023年12月' },
+  { id: 11, labId: 'materials_science', awardName: '日本表面真空学会 学術講演会講演奨励賞', awardedAt: '2023年11月' },
+  { id: 12, labId: 'materials_science', awardName: '化学工学会 優秀学生賞', awardedAt: '2024年3月' },
+  { id: 13, labId: 'materials_science', awardName: 'ナノテクノロジー総合シンポジウム ポスター賞', awardedAt: '2023年2月' },
+  { id: 14, labId: 'materials_science', awardName: 'MRS Fall Meeting Best Poster', awardedAt: '2022年11月' },
+  { id: 15, labId: 'materials_science', awardName: '高分子学会 優秀ポスター賞', awardedAt: '2022年9月' },
+  { id: 16, labId: 'materials_science', awardName: '文部科学大臣表彰 若手科学者賞', awardedAt: '2022年4月' },
+
+  // --- AIロボティクス研究室 (12件) ---
+  { id: 17, labId: 'ai_robotics', awardName: 'CVPR Best Paper Award', awardedAt: '2023年6月' },
+  { id: 18, labId: 'ai_robotics', awardName: 'ICML Outstanding Paper Award', awardedAt: '2024年7月' },
+  { id: 19, labId: 'ai_robotics', awardName: 'NeurIPS Spotlight Presentation', awardedAt: '2024年12月' },
+  { id: 20, labId: 'ai_robotics', awardName: 'ICLR Outstanding Paper Award', awardedAt: '2024年5月' },
+  { id: 21, labId: 'ai_robotics', awardName: 'ECCV Best Poster Award', awardedAt: '2024年10月' },
+  { id: 22, labId: 'ai_robotics', awardName: '情報処理学会 山下記念研究賞', awardedAt: '2023年3月' },
+  { id: 23, labId: 'ai_robotics', awardName: 'AAAI Distinguished Paper Award', awardedAt: '2023年2月' },
+  { id: 24, labId: 'ai_robotics', awardName: 'ICCV Best Student Paper Award', awardedAt: '2023年10月' },
+  { id: 25, labId: 'ai_robotics', awardName: '人工知能学会 全国大会優秀賞', awardedAt: '2022年6月' },
+  { id: 26, labId: 'ai_robotics', awardName: 'Google PhD Fellowship', awardedAt: '2022年9月' },
+  { id: 27, labId: 'ai_robotics', awardName: 'Microsoft Research PhD Fellowship', awardedAt: '2023年8月' },
+  { id: 28, labId: 'ai_robotics', awardName: 'ACL Best Demo Paper Award', awardedAt: '2022年5月' },
+
+  // --- ヒューマンインタフェース研究室 (6件) ---
+  { id: 29, labId: 'human_interface', awardName: 'ACM CHI Honorable Mention Award', awardedAt: '2024年5月' },
+  { id: 30, labId: 'human_interface', awardName: 'IEEE VR Best Poster Award', awardedAt: '2024年3月' },
+  { id: 31, labId: 'human_interface', awardName: 'UIST Best Demo Award', awardedAt: '2023年10月' },
+  { id: 32, labId: 'human_interface', awardName: 'ヒューマンインタフェース学会 論文賞', awardedAt: '2023年9月' },
+  { id: 33, labId: 'human_interface', awardName: 'インタラクション 優秀発表賞', awardedAt: '2023年3月' },
+  { id: 34, labId: 'human_interface', awardName: 'SIGGRAPH Emerging Technologies Prize', awardedAt: '2022年8月' },
 ];

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,5 @@
 import type { Lab, Review } from '.././types/'
+import type { Award } from '../types';
 
 // --- 初期データ ---
 export const initialLabs: Lab[] = [
@@ -66,4 +67,13 @@ export const initialReviews: Review[] = [
     { id: 4, labId: 'materials_science', labName: '材料科学研究室', strict: 9, supportive: 9, comment: 'コアタイムが長く大変だが、その分成長できる環境。' },
     { id: 5, labId: 'ai_robotics', labName: 'AIロボティクス研究室', strict: 5, supportive: 2, comment: '完全な放置。自分でテーマを見つけられる人向け。' },
     { id: 6, labId: 'human_interface', labName: 'ヒューマンインタフェース研究室', strict: 4, supportive: 6, comment: '和気あいあいとした雰囲気で楽しい。' },
+];
+
+// ▼ この部分を追記
+export const initialAwards: Award[] = [
+  { id: 1, labId: 'system_control', awardName: 'ロボティクス学会 年次大会優秀講演賞', awardedAt: '2024年9月' },
+  { id: 2, labId: 'system_control', awardName: '国際自動制御連盟 世界大会ポスター賞', awardedAt: '2023年7月' },
+  { id: 3, labId: 'materials_science', awardName: '応用物理学会 論文賞', awardedAt: '2024年3月' },
+  { id: 4, labId: 'ai_robotics', awardName: 'CVPR Best Paper Award', awardedAt: '2023年6月' },
+  { id: 5, labId: 'ai_robotics', awardName: 'ICML Outstanding Paper Award', awardedAt: '2024年7月' },
 ];

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -22,7 +22,7 @@ export const initialLabs: Lab[] = [
     schedule: '隔週ミーティング',
     decision: '共同決定', // チームでの議論を重視
     conference: '国際学会（推奨）', // 国際学会での発表を推奨
-    rewards: 5,
+    rewards: 0,
     career: '通信キャリア, IT企業'
   },
   {
@@ -69,49 +69,44 @@ export const initialReviews: Review[] = [
     { id: 6, labId: 'human_interface', labName: 'ヒューマンインタフェース研究室', strict: 4, supportive: 6, comment: '和気あいあいとした雰囲気で楽しい。' },
 ];
 
-// ▼ この部分を追記
 export const initialAwards: Award[] = [
   // --- システム制御論研究室 (3件) ---
   { id: 1, labId: 'system_control', awardName: 'ロボティクス学会 年次大会優秀講演賞', awardedAt: '2024年9月' },
   { id: 2, labId: 'system_control', awardName: '国際自動制御連盟 世界大会ポスター賞', awardedAt: '2023年7月' },
   { id: 3, labId: 'system_control', awardName: '計測自動制御学会 論文賞', awardedAt: '2022年11月' },
 
-  // --- 通信方式研究室 (5件) ---
-  { id: 4, labId: 'communication_theory', awardName: 'IEEE VTC Best Paper Award', awardedAt: '2024年5月' },
-  { id: 5, labId: 'communication_theory', awardName: '電子情報通信学会 業績賞', awardedAt: '2023年10月' },
-  { id: 6, labId: 'communication_theory', awardName: 'Globecom Student Travel Grant', awardedAt: '2023年12月' },
-  { id: 7, labId: 'communication_theory', awardName: '総務省SCOPE採択', awardedAt: '2022年4月' },
-  { id: 8, labId: 'communication_theory', awardName: 'IEEE ICC Poster Award', awardedAt: '2022年5月' },
+  // --- 通信方式研究室 (0件) ---
+  // 受賞データなし
 
   // --- 材料科学研究室 (8件) ---
-  { id: 9, labId: 'materials_science', awardName: '応用物理学会 論文賞', awardedAt: '2024年3月' },
-  { id: 10, labId: 'materials_science', awardName: '日本MRS年次大会 奨励賞', awardedAt: '2023年12月' },
-  { id: 11, labId: 'materials_science', awardName: '日本表面真空学会 学術講演会講演奨励賞', awardedAt: '2023年11月' },
-  { id: 12, labId: 'materials_science', awardName: '化学工学会 優秀学生賞', awardedAt: '2024年3月' },
-  { id: 13, labId: 'materials_science', awardName: 'ナノテクノロジー総合シンポジウム ポスター賞', awardedAt: '2023年2月' },
-  { id: 14, labId: 'materials_science', awardName: 'MRS Fall Meeting Best Poster', awardedAt: '2022年11月' },
-  { id: 15, labId: 'materials_science', awardName: '高分子学会 優秀ポスター賞', awardedAt: '2022年9月' },
-  { id: 16, labId: 'materials_science', awardName: '文部科学大臣表彰 若手科学者賞', awardedAt: '2022年4月' },
+  { id: 4, labId: 'materials_science', awardName: '応用物理学会 論文賞', awardedAt: '2024年3月' },
+  { id: 5, labId: 'materials_science', awardName: '日本MRS年次大会 奨励賞', awardedAt: '2023年12月' },
+  { id: 6, labId: 'materials_science', awardName: '日本表面真空学会 学術講演会講演奨励賞', awardedAt: '2023年11月' },
+  { id: 7, labId: 'materials_science', awardName: '化学工学会 優秀学生賞', awardedAt: '2024年3月' },
+  { id: 8, labId: 'materials_science', awardName: 'ナノテクノロジー総合シンポジウム ポスター賞', awardedAt: '2023年2月' },
+  { id: 9, labId: 'materials_science', awardName: 'MRS Fall Meeting Best Poster', awardedAt: '2022年11月' },
+  { id: 10, labId: 'materials_science', awardName: '高分子学会 優秀ポスター賞', awardedAt: '2022年9月' },
+  { id: 11, labId: 'materials_science', awardName: '文部科学大臣表彰 若手科学者賞', awardedAt: '2022年4月' },
 
   // --- AIロボティクス研究室 (12件) ---
-  { id: 17, labId: 'ai_robotics', awardName: 'CVPR Best Paper Award', awardedAt: '2023年6月' },
-  { id: 18, labId: 'ai_robotics', awardName: 'ICML Outstanding Paper Award', awardedAt: '2024年7月' },
-  { id: 19, labId: 'ai_robotics', awardName: 'NeurIPS Spotlight Presentation', awardedAt: '2024年12月' },
-  { id: 20, labId: 'ai_robotics', awardName: 'ICLR Outstanding Paper Award', awardedAt: '2024年5月' },
-  { id: 21, labId: 'ai_robotics', awardName: 'ECCV Best Poster Award', awardedAt: '2024年10月' },
-  { id: 22, labId: 'ai_robotics', awardName: '情報処理学会 山下記念研究賞', awardedAt: '2023年3月' },
-  { id: 23, labId: 'ai_robotics', awardName: 'AAAI Distinguished Paper Award', awardedAt: '2023年2月' },
-  { id: 24, labId: 'ai_robotics', awardName: 'ICCV Best Student Paper Award', awardedAt: '2023年10月' },
-  { id: 25, labId: 'ai_robotics', awardName: '人工知能学会 全国大会優秀賞', awardedAt: '2022年6月' },
-  { id: 26, labId: 'ai_robotics', awardName: 'Google PhD Fellowship', awardedAt: '2022年9月' },
-  { id: 27, labId: 'ai_robotics', awardName: 'Microsoft Research PhD Fellowship', awardedAt: '2023年8月' },
-  { id: 28, labId: 'ai_robotics', awardName: 'ACL Best Demo Paper Award', awardedAt: '2022年5月' },
+  { id: 12, labId: 'ai_robotics', awardName: 'CVPR Best Paper Award', awardedAt: '2023年6月' },
+  { id: 13, labId: 'ai_robotics', awardName: 'ICML Outstanding Paper Award', awardedAt: '2024年7月' },
+  { id: 14, labId: 'ai_robotics', awardName: 'NeurIPS Spotlight Presentation', awardedAt: '2024年12月' },
+  { id: 15, labId: 'ai_robotics', awardName: 'ICLR Outstanding Paper Award', awardedAt: '2024年5月' },
+  { id: 16, labId: 'ai_robotics', awardName: 'ECCV Best Poster Award', awardedAt: '2024年10月' },
+  { id: 17, labId: 'ai_robotics', awardName: '情報処理学会 山下記念研究賞', awardedAt: '2023年3月' },
+  { id: 18, labId: 'ai_robotics', awardName: 'AAAI Distinguished Paper Award', awardedAt: '2023年2月' },
+  { id: 19, labId: 'ai_robotics', awardName: 'ICCV Best Student Paper Award', awardedAt: '2023年10月' },
+  { id: 20, labId: 'ai_robotics', awardName: '人工知能学会 全国大会優秀賞', awardedAt: '2022年6月' },
+  { id: 21, labId: 'ai_robotics', awardName: 'Google PhD Fellowship', awardedAt: '2022年9月' },
+  { id: 22, labId: 'ai_robotics', awardName: 'Microsoft Research PhD Fellowship', awardedAt: '2023年8月' },
+  { id: 23, labId: 'ai_robotics', awardName: 'ACL Best Demo Paper Award', awardedAt: '2022年5月' },
 
   // --- ヒューマンインタフェース研究室 (6件) ---
-  { id: 29, labId: 'human_interface', awardName: 'ACM CHI Honorable Mention Award', awardedAt: '2024年5月' },
-  { id: 30, labId: 'human_interface', awardName: 'IEEE VR Best Poster Award', awardedAt: '2024年3月' },
-  { id: 31, labId: 'human_interface', awardName: 'UIST Best Demo Award', awardedAt: '2023年10月' },
-  { id: 32, labId: 'human_interface', awardName: 'ヒューマンインタフェース学会 論文賞', awardedAt: '2023年9月' },
-  { id: 33, labId: 'human_interface', awardName: 'インタラクション 優秀発表賞', awardedAt: '2023年3月' },
-  { id: 34, labId: 'human_interface', awardName: 'SIGGRAPH Emerging Technologies Prize', awardedAt: '2022年8月' },
+  { id: 24, labId: 'human_interface', awardName: 'ACM CHI Honorable Mention Award', awardedAt: '2024年5月' },
+  { id: 25, labId: 'human_interface', awardName: 'IEEE VR Best Poster Award', awardedAt: '2024年3月' },
+  { id: 26, labId: 'human_interface', awardName: 'UIST Best Demo Award', awardedAt: '2023年10月' },
+  { id: 27, labId: 'human_interface', awardName: 'ヒューマンインタフェース学会 論文賞', awardedAt: '2023年9月' },
+  { id: 28, labId: 'human_interface', awardName: 'インタラクション 優秀発表賞', awardedAt: '2023年3月' },
+  { id: 29, labId: 'human_interface', awardName: 'SIGGRAPH Emerging Technologies Prize', awardedAt: '2022年8月' },
 ];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,10 +9,12 @@ import { useDataContext } from '.././contexts/DataContext';
 
 interface HomePageProps {
   onReviewClick: (lab: LabWithReview) => void;
+  onAwardsClick: (lab: LabWithReview) => void;
+  
 }
 
 // ホームページコンポーネント
-const HomePage: FC<HomePageProps> = ({ onReviewClick }) => {
+const HomePage: FC<HomePageProps> = ({ onReviewClick, onAwardsClick }) => {
   const { labs, reviews } = useDataContext();
   const [searchTerm, setSearchTerm] = useState<string>('');
 
@@ -83,7 +85,16 @@ const HomePage: FC<HomePageProps> = ({ onReviewClick }) => {
                 <td className="px-6 py-4 hidden lg:table-cell">{lab.schedule}</td>
                 <td className="px-6 py-4 hidden lg:table-cell">{lab.decision}</td>
                 <td className="px-6 py-4 hidden lg:table-cell">{lab.conference}</td>
-                <td className="px-6 py-4 hidden lg:table-cell">{lab.rewards}</td>
+                <td className="px-6 py-4 hidden lg:table-cell">
+                  <button
+                  onClick={() => onAwardsClick(lab)}
+                  className="text-blue-600 hover:underline disabled:text-gray-400 disabled:no-underline"
+                  disabled={lab.rewards === 0}
+                  >
+                    {lab.rewards} 
+                    </button>
+                </td>
+
                 <td className="px-6 py-4 hidden lg:table-cell">{lab.career}</td>
               </tr>
             ))}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,3 +30,11 @@ export interface LabWithReview extends Lab {
 
 // pageの型定義, これを状態として管理することで、状態がセットされるたびに際レンダリングが自動で開始
 export type Page = 'home' | 'chart' | 'form';
+
+// ▼ この部分を追記
+export interface Award {
+  id: number;
+  labId: string;
+  awardName: string;
+  awardedAt: string;
+}


### PR DESCRIPTION
## 概要
新機能として受賞歴モーダルを実装しました。

## 主な変更点
### 受賞歴モーダル機能
- 受賞歴データ（`Award`型、仮データ）を追加
- 受賞歴を表示するための`AwardModal.tsx`を新規作成
- `HomePage.tsx`の「受賞数」をクリックするとモーダルが開くように修正
- `DataContext`と`App.tsx`を更新し、モーダル表示のロジックを全体に統合

## 動作確認の方法
1.  アプリを起動 (`npm run dev`)
2.  ブラウザのタブとヘッダーに新しいロゴが表示されていることを確認してください。
3.  ホームページのテーブルで「受賞数」が0でない研究室（例: システム制御論研究室）の数字をクリックしてください。
4.  対応する受賞歴がモーダルで正しく表示され、正常に閉じることを確認してください。